### PR TITLE
Add missing doctoc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "coveralls": "^2.11.6",
     "grunt": "^0.4.5",
+    "doctoc": "^1.0.0",
     "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-cssmin": "^0.14.0",
     "grunt-contrib-jshint": "^1.0.0",


### PR DESCRIPTION
I added the doctoc dependency to the package.json file. 

```
Running "doctoc:readme" (doctoc) task
Fatal error: module.js:341
    throw err;
    ^

Error: Cannot find module '/dev/meteor-gridstack-angular/lib/gridstack.js/node_modules/grunt-doctoc/node_modules/doctoc/doctoc.js'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:140:18)
    at node.js:1001:3
```
